### PR TITLE
Rewriting the implementation to only queue objects which inherit from…

### DIFF
--- a/queued_search/models.py
+++ b/queued_search/models.py
@@ -1,2 +1,6 @@
-# O HAI.
-# Faking ``models.py`` so Django sees the app/management command.
+class QueuedModel(object):
+    """
+        Empty class just to add new parent type. Models which we want to be inserted in
+          the search queue should subclass from this.
+    """
+    pass

--- a/queued_search/signals.py
+++ b/queued_search/signals.py
@@ -3,7 +3,9 @@ from django.db import models
 from haystack.signals import BaseSignalProcessor
 from haystack.utils import get_identifier
 from queued_search.utils import get_queue_name
+from queued_search.models import QueuedModel
 
+import inspect
 
 class QueuedSignalProcessor(BaseSignalProcessor):
     def setup(self):
@@ -30,6 +32,7 @@ class QueuedSignalProcessor(BaseSignalProcessor):
             # ...or...
             ``delete:weblog.entry.8``
         """
-        message = "%s:%s" % (action, get_identifier(instance))
-        queue = queues.Queue(get_queue_name())
-        return queue.write(message)
+        if isinstance(instance, QueuedModel):
+            message = "%s:%s" % (action, get_identifier(instance))
+            queue = queues.Queue(get_queue_name())
+            return queue.write(message)


### PR DESCRIPTION
Updating the project. Now only models which subclass QueuedModel will be insterted in the AWS queue. That is, every model with a search index should subclass that class.